### PR TITLE
Fix issue with gitconfig

### DIFF
--- a/nix-mineral.nix
+++ b/nix-mineral.nix
@@ -402,7 +402,7 @@ in
 
     # Borrow Kicksecure gitconfig, disabling git symlinks and enabling fsck
     # by default for better git security.
-    gitconfig.source = fetchGhFile sources.gitconfig;
+    gitconfig.source = lib.mkDefault (fetchGhFile sources.gitconfig);
 
     # Borrow Kicksecure bluetooth configuration for better bluetooth privacy
     # and security. Disables bluetooth automatically when not connected to


### PR DESCRIPTION
If git LFS is enabled, `programs.git.config` is set, causing `environment.etc.gitconfig` to be set, causing an error.