### PR TITLE
fix: don't define device for /boot

### DIFF
--- a/nix-mineral.nix
+++ b/nix-mineral.nix
@@ -1023,7 +1023,6 @@ in
         };
 
         "/boot" = {
-          device = "/boot";
           options = [
             "nosuid"
             "noexec"


### PR DESCRIPTION
Since it's not usually a bind mount.