### PR TITLE
Fix NTS

### DIFF
--- a/nix-mineral.nix
+++ b/nix-mineral.nix
@@ -1204,6 +1204,17 @@ in
         # or an error will be thrown due to these options conflicting with
         # eachother.
 
+        servers = l.mkDefault [ ];
+        # Since servers are declared by the fetched chrony config, set the
+        # NixOS option to [ ] to prevent the default values from interfering.
+
+        initstepslew.enabled = l.mkDefault false;
+        # Initstepslew "is deprecated in favour of the makestep directive"
+        # according to:
+        # https://chrony-project.org/doc/4.6/chrony.conf.html#initstepslew.
+        # The fetched chrony config already has makestep enabled, so
+        # initstepslew is disabled (it is enabled by default).
+
         # The below config is borrowed from GrapheneOS server infrastructure.
         # It enables NTS to secure NTP requests, among some other useful
         # settings.


### PR DESCRIPTION
The NixOS default values for chrony interfere with the content from the fetched chrony.conf file. By default these settings are added to the chrony.conf generated in the nix store:

```conf
server [0.nixos.pool.ntp.org](http://0.nixos.pool.ntp.org/) iburst
server [1.nixos.pool.ntp.org](http://1.nixos.pool.ntp.org/) iburst
server [2.nixos.pool.ntp.org](http://2.nixos.pool.ntp.org/) iburst
server [3.nixos.pool.ntp.org](http://3.nixos.pool.ntp.org/) iburst

initstepslew 1000 [0.nixos.pool.ntp.org](http://0.nixos.pool.ntp.org/) [1.nixos.pool.ntp.org](http://1.nixos.pool.ntp.org/) [2.nixos.pool.ntp.org](http://2.nixos.pool.ntp.org/) [3.nixos.pool.ntp.org](http://3.nixos.pool.ntp.org/)
```

This pr sets the following values `chrony.servers = [ ];` and `chrony.initstepslew.enabled = false;` to prevent interference with the input of the fetched chrony.conf settings.

Please feel free to edit/review.