### PR TITLE
Doas sudo wrapper fixes & rule change

### DIFF
--- a/nix-mineral.nix
+++ b/nix-mineral.nix
@@ -1096,7 +1096,7 @@ in
           {
             keepEnv = l.mkDefault true;
             persist = l.mkDefault true;
-            users = l.mkDefault [ "user" ];
+            groups = l.mkDefault [ "wheel" ];
           }
         ];
       };


### PR DESCRIPTION
The current scripts don't work as they use the unwrapped binary, resulting in a `doas: not installed setuid` error. I've made them use `/run/wrappers/bin/doas`, which fixes the issue.