### PR TITLE
Rename option.system for options.entropy in entropy.nix

### DIFF
--- a/settings/entropy/default.nix
+++ b/settings/entropy/default.nix
@@ -42,9 +42,9 @@ let
 in
 {
   options = {
-    system = l.mkOption {
+    entropy = l.mkOption {
       description = ''
-        Settings for the system.
+        Settings for entropy sources.
       '';
       default = { };
       type = l.mkCategorySubmodule categoryModules;


### PR DESCRIPTION
This will throw an error having options.system duplicated