### PR TITLE
correct proc-mem-force.nix sysctl params

### DIFF
--- a/settings/system/proc-mem-force.nix
+++ b/settings/system/proc-mem-force.nix
@@ -34,17 +34,17 @@
         `ptrace` - Only allow modification of memory mappings using ptrace. Affected by the "yama" option.
         `never` - Do not allow modifying memory mappings at all.
       '';
-      default = "relaxed";
+      default = "ptrace";
       type = l.types.enum [
         "none"
-        "relaxed"
-        "restricted"
+        "ptrace"
+        "never"
       ];
     };
   };
 
   config = l.mkIf (cfg != "none") {
-    boot.kernel.sysctl."kernel.yama.ptrace_scope" = l.mkForce (
+    boot.kernel.sysctl."proc_mem.force_override" = l.mkForce (
       if cfg == "ptrace" then "ptrace" else "never"
     );
   };


### PR DESCRIPTION
correct the param name to `proc_mem.force_override` and the options.

otherwise this results in a potentially incorrect kernel sysctl params and a conflict of the definition.

the default, I've inferred from the linked Kicksecure discussion but maybe isn't the nix-mineral choice.

this change fixes a conflict with `settings.system.yama` by default (I.E. neither is set to `"none"`) https://github.com/cynicsketch/nix-mineral/blob/b21b4311620a9affea7866f41e5b87fce4843d63/settings/system/yama.nix#L47