### PR TITLE
update renamed systemd-resolved dnssec option

### DIFF
--- a/settings/misc/dnssec.nix
+++ b/settings/misc/dnssec.nix
@@ -36,6 +36,6 @@
   };
 
   config = l.mkIf cfg {
-    services.resolved.dnssec = l.mkDefault "true";
+    services.resolved.settings.Resolve.DNSSEC = l.mkDefault "true";
   };
 }


### PR DESCRIPTION
The systemd-resolved options were renamed in https://github.com/NixOS/nixpkgs/pull/416720.

The DNSSEC module should use the new option names to avoid evaluation warnings.