### PR TITLE
Update coredump option due to changes upstream

### DIFF
--- a/settings/debug/coredump.nix
+++ b/settings/debug/coredump.nix
@@ -54,8 +54,6 @@
       }
     ];
     # Don't store coredumps from systemd-coredump.
-    systemd.coredump.extraConfig = ''
-      Storage=none
-    '';
+    systemd.coredump.settings.Coredump.Storage = "none";
   };
 }


### PR DESCRIPTION
The coredump option has been migrated to RFC 42-style settings in https://github.com/NixOS/nixpkgs/commit/ab076fc22ddb751249a518de8b3217e1097bcb82.