### PR TITLE
Avoid failing tests and fix oversight with broken links on the website

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -45,7 +45,7 @@ jobs:
 
       - name: Build HTML documentation
         run: |
-          nix build .#docs -Lv
+          nix build .#docs-nix-mineral -Lv
 
           # Copy the build manual to the public dir
           # which we will serve

--- a/docs/package.nix
+++ b/docs/package.nix
@@ -285,21 +285,6 @@ rec {
       ''
   ) { };
 
-  html =
-    pkgs.runCommand "nix-mineral-docs-html"
-      {
-        nativeBuildInputs = [ docs ];
-      }
-      ''
-        mkdir -p $out/bin
-
-        cp ${pkgs.writeShellScript "nix-mineral-docs-html" ''
-          cp -r ${docs}/share/doc ./nix-mineral-docs
-          chown -R $(whoami) ./nix-mineral-docs
-          chmod -R u+w ./nix-mineral-docs
-        ''} $out/bin/nix-mineral-docs-html
-      '';
-
   nix-mineral-prefix = docs.override {
     urlPrefix = "nix-mineral";
   };

--- a/docs/package.nix
+++ b/docs/package.nix
@@ -300,6 +300,10 @@ rec {
         ''} $out/bin/nix-mineral-docs-html
       '';
 
+  nix-mineral-prefix = docs.override {
+    urlPrefix = "nix-mineral";
+  };
+
   server =
     pkgs.runCommand "nix-mineral-docs-server"
       {

--- a/docs/package.nix
+++ b/docs/package.nix
@@ -228,10 +228,16 @@ let
     }).optionsJSON;
 in
 rec {
-  docs =
+  docs = pkgs.callPackage (
+    {
+      runCommand,
+      # Prefix where the web interface should be served,
+      # this will be used to fix the links in the documentation to work correctly when served in a subpath.
+      urlPrefix ? "",
+    }:
     # based on: https://github.com/feel-co/hjem/blob/6e144632e3d8cfa7d7cfcc9504e10a032837f22a/docs/package.nix#L116
     # default configuration from: https://github.com/feel-co/ndg/blob/a6bd3c1ce2668d096e4fdaaa03ad7f03ba1fbca8/ndg/README.md?plain=1#L309
-    pkgs.runCommand "nix-mineral-docs"
+    runCommand "nix-mineral-docs"
       {
         nativeBuildInputs = [ inputs.ndg.packages.${pkgs.hostPlatform.system}.ndg ];
       }
@@ -256,13 +262,14 @@ rec {
                   ++ [ "index.md" ] # include index.md which is the copy of README.md
                 )
               );
+            prefix = lib.replaceStrings [ "/" ] [ "\\/" ] (if urlPrefix == "" then "" else "${urlPrefix}/");
           in
           (mapMdFiles (
             fileName:
             "${mapMdFiles (
               innerFileName:
-              "sed -i 's/](docs\\/${fileName})/](\\/\\${lib.removeSuffix ".md" fileName})/g' ./inputs/${innerFileName}
-                sed -i 's/](${fileName})/](\\/\\${lib.removeSuffix ".md" fileName})/g' ./inputs/${innerFileName}"
+              "sed -i 's/](docs\\/${fileName})/](${prefix}${lib.removeSuffix ".md" fileName})/g' ./inputs/${innerFileName}
+                sed -i 's/](${fileName})/](${prefix}${lib.removeSuffix ".md" fileName})/g' ./inputs/${innerFileName}"
             )}"
           ))
         }
@@ -275,7 +282,8 @@ rec {
           --config output_dir=$out/share/doc \
           --config jobs=$NIX_BUILD_CORES \
           html --module-options ${configJSON}/share/doc/nixos/options.json
-      '';
+      ''
+  ) { };
 
   html =
     pkgs.runCommand "nix-mineral-docs-html"

--- a/flake.nix
+++ b/flake.nix
@@ -48,7 +48,7 @@
 
           packages =
             let
-              docs = pkgs.callPackage ./docs/package.nix {
+              docs = import ./docs/package.nix {
                 inherit inputs pkgs;
               };
             in

--- a/flake.nix
+++ b/flake.nix
@@ -56,6 +56,7 @@
               docs = docs.docs;
               docs-server = docs.server;
               docs-html = docs.html;
+              docs-nix-mineral = docs.nix-mineral-prefix;
             };
         };
 

--- a/flake.nix
+++ b/flake.nix
@@ -55,7 +55,6 @@
             {
               docs = docs.docs;
               docs-server = docs.server;
-              docs-html = docs.html;
               docs-nix-mineral = docs.nix-mineral-prefix;
             };
         };

--- a/settings/kernel/algif-kmodules.nix
+++ b/settings/kernel/algif-kmodules.nix
@@ -21,25 +21,39 @@
   ...
 }:
 
+let
+  # Only enable if `networking.wireless.iwd.enable` exists (avoid failing tests) and is enabled, since iwd uses AF_ALG.
+  iwdEnabled =
+    config ? networking
+    && config.networking ? wireless
+    && config.networking.wireless ? iwd
+    && config.networking.wireless.iwd ? enable
+    && config.networking.wireless.iwd.enable;
+in
 {
   options = {
-    algif-kmodules = l.mkBoolOption ''
-      Algif related kernel modules.
+    algif-kmodules =
+      l.mkBoolOption ''
+        Algif related kernel modules.
 
-      The existence of AF_ALG has been criticized for a long time,
-      and has been the source of multiple vulnerabilities such as [CVE-2026-31431](https://github.com/advisories/GHSA-2274-3hgr-wxv6).
+        The existence of AF_ALG has been criticized for a long time,
+        and has been the source of multiple vulnerabilities such as [CVE-2026-31431](https://github.com/advisories/GHSA-2274-3hgr-wxv6).
 
-      AF_ALG is practically only used in some unspecified rare and bespoke applications,
-      so normally you can disable this without any consequences.
+        AF_ALG is practically only used in some unspecified rare and bespoke applications,
+        so normally you can disable this without any consequences.
 
-      ::: {.note}
-      Read more:
-      - https://lore.kernel.org/all/20260430021042.GA51782@sol/
-      - https://www.chronox.de/libkcapi/html/ch01s02.html
-      - https://lore.kernel.org/all/CAMj1kXGxxRs6Rkhevm9NSY6TaJUsOmF3UqdHUo=NRg9kQKtSBA@mail.gmail.com/
-      - https://news.ycombinator.com/item?id=47956312
-      :::
-    '' config.networking.wireless.iwd.enable;
+        ::: {.note}
+        Read more:
+        - https://lore.kernel.org/all/20260430021042.GA51782@sol/
+        - https://www.chronox.de/libkcapi/html/ch01s02.html
+        - https://lore.kernel.org/all/CAMj1kXGxxRs6Rkhevm9NSY6TaJUsOmF3UqdHUo=NRg9kQKtSBA@mail.gmail.com/
+        - https://news.ycombinator.com/item?id=47956312
+        :::
+      '' iwdEnabled
+      // {
+        # Make it clear in the documentation that this option is enabled if `networking.wireless.iwd.enable` is enabled.
+        defaultText = l.literalExpression "networking.wireless.iwd.enable";
+      };
   };
 
   config = l.mkIf (!cfg) {


### PR DESCRIPTION
To avoid failing tests, we simply check if the iwd option exists before using it.

Regarding the broken links in issue #124, that was fixed in pr #130, but only when the documentation is used locally with something like `nix run github:cynicsketch/nix-mineral#docs-server`.
I did not realize that the website had a "/nix-mineral/" prefix lol...

NDG does not have a native feature to handle this problem (judging by the fact that [it happens within their official documentation](https://ndg.feel-co.org/index.html), search "templating documentation").
So we run a script before the documentation is built to manually fix the paths, but for it to work properly the script needs to know if you are using a prefix for the url and what that prefix is, so I created an optional override in the package to set that up if needed.

I tried to find a way to pass the override value using the nix build command, but I couldn't, so for now I created a separate package `docs-nix-mineral` with the prefix for the website. And I removed `docs-html` because it did the same thing as building `docs`.