### PR TITLE
Improve zram option

### DIFF
--- a/extras/system/zram.nix
+++ b/extras/system/zram.nix
@@ -29,15 +29,18 @@
       Improves storage lifespan and overall performance when swapping as a
       side effect.
 
+      Enabling this option disables zswap.
+
       ::: {.note}
       Not enabled by default due to interfering with zswap. Additionally, the
       task of limiting swapping of sensitive data depends highly on the user's
       individual swapping setup which can't be reliably inferred.
       :::
-    '' true;
+    '' false;
   };
 
   config = l.mkIf cfg {
     zramSwap.enable = true;
+    boot.zswap.enable = false;
   };
 }

--- a/presets/performance.nix
+++ b/presets/performance.nix
@@ -50,7 +50,13 @@
         # it adds significant memory allocation overhead.
         slab-debug = false;
       };
-
+    };
+    extras = {
+      system = {
+        # Enabling zram improves swapping performance and desktop responsiveness.
+        # Aditionally, decreases swapping to disk, improving security and lifespan.
+        zram = true;
+      };
     };
   };
 }


### PR DESCRIPTION
I noticed the zram option said it was disabled by defaut when actually it was enabled by default, so I modified it to be disabled by default, disable zswap by default when it's enabled, and added it to the performance profile.