### PR TITLE
Flake check improvements

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -9,4 +9,4 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - uses: cachix/install-nix-action@v31
-      - run: nix flake check --all-systems
+      - run: nix flake check ./tests/nixos-stub/ --all-systems

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,4 +1,4 @@
-name: Evaluate
+name: Evaluate module on a NixOS flake
 
 on: [push, pull_request, workflow_dispatch]
 

--- a/.github/workflows/update-test-flake-lock.yml
+++ b/.github/workflows/update-test-flake-lock.yml
@@ -1,0 +1,25 @@
+name: "Flake.lock: update Nix dependencies (NixOS stub flake for CI)"
+
+on:
+  schedule:
+    - cron: '0 0 * * 0' # runs weekly on Sunday at 00:00
+  workflow_dispatch: # allows manual triggering
+
+jobs:
+  nixos-stub-flake-update:
+    permissions:
+      contents: write
+      id-token: write
+      issues: write
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: DeterminateSystems/determinate-nix-action@v3
+      - uses: DeterminateSystems/update-flake-lock@main
+        with:
+          path-to-flake-dir: 'tests/nixos-stub/' # path to nixos-stub flake
+          pr-title: "Update Nix flake inputs"
+          pr-labels: |
+            dependencies
+            automated

--- a/settings/kernel/algif-kmodules.nix
+++ b/settings/kernel/algif-kmodules.nix
@@ -21,15 +21,6 @@
   ...
 }:
 
-let
-  # Only enable if `networking.wireless.iwd.enable` exists (avoid failing tests) and is enabled, since iwd uses AF_ALG.
-  iwdEnabled =
-    config ? networking
-    && config.networking ? wireless
-    && config.networking.wireless ? iwd
-    && config.networking.wireless.iwd ? enable
-    && config.networking.wireless.iwd.enable;
-in
 {
   options = {
     algif-kmodules =
@@ -53,7 +44,7 @@ in
         - https://lore.kernel.org/all/CAMj1kXGxxRs6Rkhevm9NSY6TaJUsOmF3UqdHUo=NRg9kQKtSBA@mail.gmail.com/
         - https://news.ycombinator.com/item?id=47956312
         :::
-      '' iwdEnabled
+      '' config.networking.wireless.iwd.enable
       // {
         # Make it clear in the documentation that this option is enabled if `networking.wireless.iwd.enable` is enabled.
         defaultText = l.literalExpression "networking.wireless.iwd.enable";

--- a/tests/nixos-stub/flake.lock
+++ b/tests/nixos-stub/flake.lock
@@ -1,0 +1,107 @@
+{
+  "nodes": {
+    "flake-compat": {
+      "locked": {
+        "lastModified": 1733328505,
+        "narHash": "sha256-NeCCThCEP3eCl2l/+27kNNK7QrwZB1IJCrXfrbv5oqU=",
+        "rev": "ff81ac966bb2cae68946d5ed5fc4994f96d0ffec",
+        "revCount": 69,
+        "type": "tarball",
+        "url": "https://api.flakehub.com/f/pinned/edolstra/flake-compat/1.1.0/01948eb7-9cba-704f-bbf3-3fa956735b52/source.tar.gz"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://flakehub.com/f/edolstra/flake-compat/1.tar.gz"
+      }
+    },
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1778716662,
+        "narHash": "sha256-m1Yf0wZ8j1OHjTc2UwHwyQRSnNeSgLJOd7q5Y45hzi4=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "f7c1a2d347e4c52d5fb8d10cb4d94b5884e546fb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "nix-mineral": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "flake-parts": "flake-parts",
+        "nixpkgs": "nixpkgs"
+      },
+      "locked": {
+        "path": "../../",
+        "type": "path"
+      },
+      "original": {
+        "path": "../../",
+        "type": "path"
+      },
+      "parent": []
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1780453794,
+        "narHash": "sha256-bXMRa9VTsHSPXL4Cw8R6JJLQeY3Y/IP4+YJCYVmQ7FY=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "6b316287bae2ee04c9b93c8c858d930fd07d7338",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-26.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib": {
+      "locked": {
+        "lastModified": 1777168982,
+        "narHash": "sha256-GOkGPcboWE9BmGCRMLX3worL4EMnsnG8MyKmXNeYuhQ=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "f5901329dade4a6ea039af1433fb087bd9c1fe14",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1782467914,
+        "narHash": "sha256-pGvFkM8N0xEkIIXDe5YYfbEAvHrk4IxBrjB/x8OomhE=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "e73de5be04e0eff4190a1432b946d469c794e7b4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nix-mineral": "nix-mineral",
+        "nixpkgs": "nixpkgs_2"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/tests/nixos-stub/flake.nix
+++ b/tests/nixos-stub/flake.nix
@@ -1,0 +1,49 @@
+{
+  description = "Test NixOS flake for using nix-mineral";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs?ref=nixos-unstable";
+    nix-mineral.url = "path:../../";
+  };
+
+  outputs =
+    { nixpkgs, ... }@inputs:
+    {
+      nixosConfigurations.test-system = nixpkgs.lib.nixosSystem {
+        system = "x86_64-linux";
+
+        specialArgs = {
+          inherit inputs;
+        };
+
+        modules = [
+          {
+            imports = [
+              inputs.nix-mineral.nixosModules.nix-mineral
+            ];
+
+            nix-mineral = {
+              enable = true;
+            };
+
+            # Everything below is required to make this configuration "bootable" and
+            # evaluate properly.
+            #
+            # Do not remove anything unless there is a good reason.
+
+            boot.loader.systemd-boot.enable = true;
+
+            # Stub filesystems
+            fileSystems."/" = {
+              device = "/dev/disk/by-uuid/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+              fsType = "ext4";
+            };
+            fileSystems."/boot" = {
+              device = "/dev/disk/by-uuid/ABCD-EFGH";
+              fsType = "vfat";
+            };
+          }
+        ];
+      };
+    };
+}


### PR DESCRIPTION
https://github.com/cynicsketch/nix-mineral/issues/157

Not sure what I want to do with the nixos-stub flake's flake.lock. 

I track nixos-unstable for development but I need to decide on an interval to update nixpkgs for the test flake. 

Also, the flake.lock there pulls in all of nix-mineral's dependencies but those would fall out of date and the lock file would eventually be wrong (although, that would cause no problems since it pulls whatever is in the current git repo anyways at runtime when `nix flake check ...` is run)

If I remove the lock file entirely and do `--no-write-lock-file` I'm not sure what the consequences would be there.

By definition, the test is supposed to be hitting a moving target, which requires some forethought since that normally defeats the purpose of using flakes at all.