### PR TITLE
Faildelay fix

### DIFF
--- a/settings/pam/login-faildelay.nix
+++ b/settings/pam/login-faildelay.nix
@@ -36,7 +36,7 @@
 
   config = l.mkIf (l.typeOf cfg == "int") {
     security.pam.services = {
-      system-login.failDelay.delay = l.mkDefault (toString cfg);
+      system-login.failDelay.delay = l.mkDefault cfg;
       system-login.failDelay.enable = l.mkDefault true;
     };
   };

--- a/settings/pam/login-faildelay.nix
+++ b/settings/pam/login-faildelay.nix
@@ -37,6 +37,7 @@
   config = l.mkIf (l.typeOf cfg == "int") {
     security.pam.services = {
       system-login.failDelay.delay = l.mkDefault (toString cfg);
+      system-login.failDelay.enable = l.mkDefault true;
     };
   };
 }


### PR DESCRIPTION
Tested manually, reading /etc/pam.d for the failDelay line:

```
~ ✗ cat /etc/pam.d/system-login | grep faildelay
auth optional /nix/store/pv8aczqkk94gzxhx0gk168gpxcll0svi-linux-pam-1.7.1/lib/security/pam_faildelay.so delay=4000000 # faildelay (order 12500)

~ → 
```

Fixes a bug where `nix-mineral.settings.pam.login-faildelay` doesn't actually apply failDelay, and fixes an adjacent bug where the type used to configure the delay in PAM was incorrect, but not observed since the line was never actually called before.