### PR TITLE
Use --replace-warn instead of deprecated --replace

### DIFF
--- a/docs/package.nix
+++ b/docs/package.nix
@@ -270,7 +270,7 @@ rec {
               );
           in
           (mapMdFiles (fileName: ''
-            substituteInPlace ./inputs/index.md --replace \
+            substituteInPlace ./inputs/index.md --replace-warn \
               '](docs/${fileName})' \
               '](${fileName})'
           ''))


### PR DESCRIPTION
Closes https://github.com/cynicsketch/nix-mineral/issues/154

Basic maintenance, built locally with no change in effective behavior.