### PR TITLE
Fix config for settings.network.arp.ignore = "local"

### DIFF
--- a/settings/network/arp.nix
+++ b/settings/network/arp.nix
@@ -85,8 +85,8 @@
       })
 
       (l.mkIf (cfg.ignore != "none") {
-        "net.ipv4.conf.default.arp_ignore" = l.mkDefault (if cfg == "local" then "1" else "2");
-        "net.ipv4.conf.all.arp_ignore" = l.mkDefault (if cfg == "local" then "1" else "2");
+        "net.ipv4.conf.default.arp_ignore" = l.mkDefault (if cfg.ignore == "local" then "1" else "2");
+        "net.ipv4.conf.all.arp_ignore" = l.mkDefault (if cfg.ignore == "local" then "1" else "2");
       })
 
       (l.mkIf cfg.drop-gratuitous {


### PR DESCRIPTION
which was previously handled the same as "link"
due to wrongly comparing with parent config.