### PR TITLE
Clarify hwrng option and provide additional reference

### DIFF
--- a/settings/entropy/hwrng.nix
+++ b/settings/entropy/hwrng.nix
@@ -23,7 +23,7 @@
 {
   options = {
     hwrng = l.mkBoolOption ''
-      Disable trusting both the CPU's hardware random number generator and any
+      Disable "trusting" both the CPU's hardware random number generator and any
       entropy seed passed to the bootloader.
 
       We assume the hardware random number generation could be flawed or buggy,
@@ -31,10 +31,40 @@
       scope and you'd have bigger problems at that point.
 
       ::: {.note}
+      Setting to false may slow down boot times because boot will not proceed
+      until adequate entropy has been acquired, and the process cannot be
+      expedited by the CPU directly.
+
+      See:
+      - https://github.com/secureblue/secureblue/issues/173
+      - https://gitlab.alpinelinux.org/alpine/aports/-/work_items/9960
+      :::
+
+      ::: {.note}
+      The use of RDRAND is *not disabled* by setting this option to false.
+
+      Trust, in this context, refers to whether a source is credited as being
+      completely reliable *by itself*.
+
+      RDRAND is still used to supplement `/dev/random` but refusing to credit it
+      means that it cannot unblock the use of `/dev/random` when used alone.
+
+      This means that we do not allow RDRAND to be the only entropy source (which
+      would only be the case in very early boot) before allowing cryptographic
+      operations to occur.
+
+      Injecting even very bad entropy sources isn't supposed to be problematic
+      into an otherwise good pool isn't supposed to be harmful, given that
+      entropy mixing works as expected and there is at least one other "good"
+      source available. There's a reason why `/dev/random` is read-write to world.
+
       See:
       - https://privsec.dev/posts/linux/desktop-linux-hardening/#entropy-generation
       - https://madaidans-insecurities.github.io/guides/linux-hardening.html#rdrand
       - https://github.com/NixOS/nixpkgs/pull/165355
+      - https://github.com/QubesOS/qubes-issues/issues/6941
+      - https://cateee.net/lkddb/web-lkddb/RANDOM_TRUST_CPU.html
+      - https://arxiv.org/abs/2312.03369
       :::
     '' false;
   };


### PR DESCRIPTION
This option was not well documented. The use of the boot parameters has been frequently confused in discussions in other projects as being dogmatic, and its actual fucntion is not well described. This commit should rectify that and clarify what trust means in the context of entropy initialization in Linux.