### PR TITLE
Check for existence of NixOS options per module

### DIFF
--- a/docs/package.nix
+++ b/docs/package.nix
@@ -117,7 +117,7 @@ let
   # https://github.com/feel-co/hjem/blob/8539013044624a257e8da370069107aea148e985/docs/package.nix#L24
   # https://github.com/snugnug/hjem-rum/blob/edac54b7d57ad72cc4b124da2f44e7b2e584f3c6/docs/package.nix#L17
   evalModules = (
-    lib.nixosSystem {
+    lib.evalModules {
       modules = [
         inputs.self.nixosModules.nix-mineral
 

--- a/docs/package.nix
+++ b/docs/package.nix
@@ -174,12 +174,7 @@ let
 
   configJSON =
     (pkgs.nixosOptionsDoc {
-      # Filter all the NixOS options from appearing in the options search
-      # Due to being pulled in from using lib.nixosSystem to avoid evaluation
-      # errors from NixOS options "not existing" during evaluation
-      options = {
-        nix-mineral = evalModules.options.nix-mineral;
-      };
+      inherit (evalModules) options;
 
       variablelistId = "nix-mineral-options";
       warningsAreErrors = true;

--- a/settings/kernel/algif-kmodules.nix
+++ b/settings/kernel/algif-kmodules.nix
@@ -21,6 +21,15 @@
   ...
 }:
 
+let
+  # Only enable if `networking.wireless.iwd.enable` exists (avoid failing tests) and is enabled, since iwd uses AF_ALG.
+  iwdEnabled =
+    config ? networking
+    && config.networking ? wireless
+    && config.networking.wireless ? iwd
+    && config.networking.wireless.iwd ? enable
+    && config.networking.wireless.iwd.enable;
+in
 {
   options = {
     algif-kmodules =
@@ -45,7 +54,7 @@
         - https://news.ycombinator.com/item?id=47956312
         - https://copy.fail/
         :::
-      '' config.networking.wireless.iwd.enable
+      '' iwdEnabled
       // {
         # Make it clear in the documentation that this option is enabled if `networking.wireless.iwd.enable` is enabled.
         defaultText = l.literalExpression "networking.wireless.iwd.enable";

--- a/settings/kernel/algif-kmodules.nix
+++ b/settings/kernel/algif-kmodules.nix
@@ -22,7 +22,9 @@
 }:
 
 let
-  # Only enable if `networking.wireless.iwd.enable` exists (avoid failing tests) and is enabled, since iwd uses AF_ALG.
+  # Check if `networking.wireless.iwd.enable` exists (to avoid causing problems
+  # with documentation generation where NixOS option context isn't pulled) and
+  # pass whether iwd is enabled since it depends on AF_ALG
   iwdEnabled =
     config ? networking
     && config.networking ? wireless

--- a/settings/kernel/slab-debug.nix
+++ b/settings/kernel/slab-debug.nix
@@ -21,6 +21,17 @@
   ...
 }:
 
+let
+  # Check if `boot.kernelPackages.kernel.version` exists (to avoid causing
+  # problems with documentation generation where NixOS option context isn't
+  # pulled) before passing string
+  kernelVersion = l.optionalString (
+    config ? boot
+    && config.boot ? kernelPackages
+    && config.boot.kernelPackages ? kernel
+    && config.boot.kernelPackages.kernel ? version
+  ) config.boot.kernelPackages.kernel.version;
+in
 {
   options = {
     slab-debug = l.mkOption {
@@ -49,7 +60,8 @@
         - https://github.com/Kicksecure/security-misc/issues/253
         :::
       '';
-      default = (l.versionAtLeast config.boot.kernelPackages.kernel.version "6.17");
+      default = (l.versionAtLeast kernelVersion "6.17");
+      defaultText = l.literalExpression ''l.versionAtLeast config.boot.kernelPackages.kernel.version "6.17"'';
       example = false;
       type = l.types.bool;
     };

--- a/settings/pam/shadow-hashing.nix
+++ b/settings/pam/shadow-hashing.nix
@@ -21,6 +21,17 @@
   ...
 }:
 
+let
+  # Check if `security.loginDefs.settings.ENCRYPT_METHOD;` exists (to avoid
+  # causing problems with documentation generation where NixOS option context
+  # isn't pulled) before passing string
+  encryptMethod = l.optionalString (
+    config ? security
+    && config.security ? loginDefs
+    && config.security.loginDefs ? settings
+    && config.security.loginDefs.settings ? ENCRYPT_METHOD
+  ) config.security.loginDefs.settings.ENCRYPT_METHOD;
+in
 {
   options = {
     shadow-hashing = l.mkOption {
@@ -63,7 +74,8 @@
         https://github.com/NixOS/nixpkgs/issues/112371
         :::
       '';
-      default = (if config.security.loginDefs.settings.ENCRYPT_METHOD == "YESCRYPT" then 8 else false);
+      default = (if encryptMethod == "YESCRYPT" then 8 else false);
+      defaultText = l.literalExpression ''if config.security.loginDefs.settings.ENCRYPT_METHOD == "YESCRYPT" then 8 else false'';
       example = false;
       type = l.types.either l.types.bool l.types.int;
     };


### PR DESCRIPTION
Closes https://github.com/cynicsketch/nix-mineral/issues/163 and https://github.com/cynicsketch/nix-mineral/issues/194

This should also make it more portable for users to generate documentation when this project is used, and reduces maintenance burden by isolating the logic out to where it's needed.