### PR TITLE
Ensure deprecation warnings show for disabled options and remove deprecated options from presets

### DIFF
--- a/extras/misc/doas-sudo-wrapper.nix
+++ b/extras/misc/doas-sudo-wrapper.nix
@@ -24,34 +24,45 @@
 
 {
   options = {
-    doas-sudo-wrapper = l.mkBoolOption ''
-      THIS OPTION IS NOW DEPRECATED. INFORMATION BELOW IS RETAINED FOR
-      FUTURE REFERENCE, AND THIS OPTION IS SCHEDULED TO BE REMOVED PENDING THE
-      NEXT RELEASE.
+    doas-sudo-wrapper = l.mkOption {
+      description = ''
+        THIS OPTION IS NOW DEPRECATED. INFORMATION BELOW IS RETAINED FOR
+        FUTURE REFERENCE, AND THIS OPTION IS SCHEDULED TO BE REMOVED PENDING THE
+        NEXT RELEASE.
 
-      This option does not fit the project's current vision. The doas port
-      in NixOS is unmaintained and not recommended for production use.
-    '' false;
+        This option does not fit the project's current vision. The doas port
+        in NixOS is unmaintained and not recommended for production use.
+      '';
+      default = null;
+      example = false;
+      type = l.types.nullOr l.types.bool;
+    };
   };
 
-  config = l.mkIf cfg {
-    warnings = l.optional cfg ''
-      The option `nix-mineral.extras.misc.doas-sudo-wrapper` is deprecated due to not
-      aligning with current project scope as well as the doas port being unmaintained,
-      and will be removed in a future release.
+  config = l.mkMerge [
+    (l.mkIf (l.typeOf cfg == "bool") {
+      warnings = [
+        ''
+          The option `nix-mineral.extras.misc.doas-sudo-wrapper` is deprecated due to not
+          aligning with current project scope as well as the doas port being unmaintained,
+          and will be removed in a future release.
 
-      Please use a different tool to get admin privliges.
-    '';
-    environment.systemPackages = with pkgs; [
-      (writeShellScriptBin "sudo" ''
-        exec ${config.security.wrapperDir}/doas "$@"
-      '')
-      (writeShellScriptBin "sudoedit" ''
-        exec ${config.security.wrapperDir}/doas ${l.getExe' nano "rnano"} "$@"
-      '')
-      (writeShellScriptBin "doasedit" ''
-        exec ${config.security.wrapperDir}/doas ${l.getExe' nano "rnano"} "$@"
-      '')
-    ];
-  };
+          Please use a different tool to get admin privliges.
+        ''
+      ];
+    })
+    (l.mkIf (cfg == true) {
+      environment.systemPackages = with pkgs; [
+        (writeShellScriptBin "sudo" ''
+          exec ${config.security.wrapperDir}/doas "$@"
+        '')
+        (writeShellScriptBin "sudoedit" ''
+          exec ${config.security.wrapperDir}/doas ${l.getExe' nano "rnano"} "$@"
+        '')
+        (writeShellScriptBin "doasedit" ''
+          exec ${config.security.wrapperDir}/doas ${l.getExe' nano "rnano"} "$@"
+        '')
+      ];
+    })
+  ];
 }

--- a/extras/misc/replace-sudo-with-doas.nix
+++ b/extras/misc/replace-sudo-with-doas.nix
@@ -22,34 +22,45 @@
 
 {
   options = {
-    replace-sudo-with-doas = l.mkBoolOption ''
-      THIS OPTION IS NOW DEPRECATED. INFORMATION BELOW IS RETAINED FOR
-      FUTURE REFERENCE, AND THIS OPTION IS SCHEDULED TO BE REMOVED PENDING THE
-      NEXT RELEASE.
+    replace-sudo-with-doas = l.mkOption {
+      description = ''
+        THIS OPTION IS NOW DEPRECATED. INFORMATION BELOW IS RETAINED FOR
+        FUTURE REFERENCE, AND THIS OPTION IS SCHEDULED TO BE REMOVED PENDING THE
+        NEXT RELEASE.
 
-      This option does not fit the project's current vision. The doas port
-      in NixOS is unmaintained and not recommended for production use.
-    '' false;
-  };
-
-  config = l.mkIf cfg {
-    warnings = l.optional cfg ''
-      The option `nix-mineral.extras.misc.replace-sudo-with-doas` is deprecated due to not
-      aligning with current project scope as well as the doas port being unmaintained,
-      and will be removed in a future release.
-
-      Please use a different tool to get admin privliges.
-    '';
-    security.sudo.enable = l.mkDefault false;
-    security.doas = {
-      enable = l.mkDefault true;
-      extraRules = [
-        {
-          keepEnv = l.mkDefault true;
-          persist = l.mkDefault true;
-          users = l.mkDefault [ "wheel" ];
-        }
-      ];
+        This option does not fit the project's current vision. The doas port
+        in NixOS is unmaintained and not recommended for production use.
+      '';
+      default = null;
+      example = false;
+      type = l.types.nullOr l.types.bool;
     };
   };
+
+  config = l.mkMerge [
+    (l.mkIf (l.typeOf cfg == "bool") {
+      warnings = [
+        ''
+          The option `nix-mineral.extras.misc.replace-sudo-with-doas` is deprecated due to not
+          aligning with current project scope as well as the doas port being unmaintained,
+          and will be removed in a future release.
+
+          Please use a different tool to get admin privliges.
+        ''
+      ];
+    })
+    (l.mkIf (cfg == true) {
+      security.sudo.enable = l.mkDefault false;
+      security.doas = {
+        enable = l.mkDefault true;
+        extraRules = [
+          {
+            keepEnv = l.mkDefault true;
+            persist = l.mkDefault true;
+            users = l.mkDefault [ "wheel" ];
+          }
+        ];
+      };
+    })
+  ];
 }

--- a/extras/misc/usbguard.nix
+++ b/extras/misc/usbguard.nix
@@ -23,84 +23,112 @@
 {
   options = {
     usbguard = {
-      enable = l.mkBoolOption ''
-        THIS OPTION IS NOW DEPRECATED. INFORMATION BELOW IS RETAINED FOR
-        FUTURE REFERENCE, AND THIS OPTION IS SCHEDULED TO BE REMOVED PENDING THE
-        NEXT RELEASE.
+      enable = l.mkOption {
+        description = ''
+          THIS OPTION IS NOW DEPRECATED. INFORMATION BELOW IS RETAINED FOR
+          FUTURE REFERENCE, AND THIS OPTION IS SCHEDULED TO BE REMOVED PENDING THE
+          NEXT RELEASE.
 
-        Enable USBGuard, a tool to restrict USB devices.
+          Enable USBGuard, a tool to restrict USB devices.
 
-        disable to avoid hassle with handling USB devices at all.
-      '' false;
+          disable to avoid hassle with handling USB devices at all.
+        '';
+        default = null;
+        example = false;
+        type = l.types.nullOr l.types.bool;
+      };
 
-      whitelist-at-boot = l.mkBoolOption ''
-        THIS OPTION IS NOW DEPRECATED. INFORMATION BELOW IS RETAINED FOR
-        FUTURE REFERENCE, AND THIS OPTION IS SCHEDULED TO BE REMOVED PENDING THE
-        NEXT RELEASE.
+      whitelist-at-boot = l.mkOption {
+        description = ''
+          THIS OPTION IS NOW DEPRECATED. INFORMATION BELOW IS RETAINED FOR
+          FUTURE REFERENCE, AND THIS OPTION IS SCHEDULED TO BE REMOVED PENDING THE
+          NEXT RELEASE.
 
-        Automatically allow all connected devices at boot in USBGuard.
+          Automatically allow all connected devices at boot in USBGuard.
 
-        If `false`, USB devices will be blocked until USBGuard is configured.
+          If `false`, USB devices will be blocked until USBGuard is configured.
 
-        ::: {.note}
-        For laptop users, inbuilt speakers and bluetooth cards may be disabled
-        by USBGuard by default, so whitelisting them manually or enabling this
-        may solve that.
-        :::
-      '' false;
+          ::: {.note}
+          For laptop users, inbuilt speakers and bluetooth cards may be disabled
+          by USBGuard by default, so whitelisting them manually or enabling this
+          may solve that.
+          :::
+        '';
+        default = null;
+        example = false;
+        type = l.types.nullOr l.types.bool;
+      };
 
-      gnome-integration = l.mkBoolOption ''
-        THIS OPTION IS NOW DEPRECATED. INFORMATION BELOW IS RETAINED FOR
-        FUTURE REFERENCE, AND THIS OPTION IS SCHEDULED TO BE REMOVED PENDING THE
-        NEXT RELEASE.
+      gnome-integration = l.mkOption {
+        description = ''
+          THIS OPTION IS NOW DEPRECATED. INFORMATION BELOW IS RETAINED FOR
+          FUTURE REFERENCE, AND THIS OPTION IS SCHEDULED TO BE REMOVED PENDING THE
+          NEXT RELEASE.
 
-        Enable USBGuard dbus daemon and add polkit rules to integrate USBGuard with
-        GNOME Shell.
+          Enable USBGuard dbus daemon and add polkit rules to integrate USBGuard with
+          GNOME Shell.
 
-        If you use GNOME, this means that USBGuard automatically
-        allows all newly connected devices while unlocked, and blacklists all
-        newly connected devices while locked. This is obviously very convenient,
-        and is similar behavior to handling USB as ChromeOS and GrapheneOS.
-      '' false;
+          If you use GNOME, this means that USBGuard automatically
+          allows all newly connected devices while unlocked, and blacklists all
+          newly connected devices while locked. This is obviously very convenient,
+          and is similar behavior to handling USB as ChromeOS and GrapheneOS.
+        '';
+        default = null;
+        example = false;
+        type = l.types.nullOr l.types.bool;
+      };
     };
   };
 
-  config = l.mkIf cfg.enable {
-    warnings = l.optional cfg.enable ''
-      The options in `nix-mineral.extras.misc.usbguard` are deprecated due to not
-      aligning with current project scope and will be removed in a future release.
+  config = l.mkMerge [
+    (l.mkIf
+      (
+        l.typeOf cfg.enable == "bool"
+        || l.typeOf cfg.whitelist-at-boot == "bool"
+        || l.typeOf cfg.gnome-integration == "bool"
+      )
+      {
+        warnings = [
+          ''
+            The options in `nix-mineral.extras.misc.usbguard` are deprecated due to not
+            aligning with current project scope and will be removed in a future release.
 
-      Replace:
-      `nix-mineral.extras.misc.usbguard.enable` --> `services.usbguard.enable`
+            Replace:
+            `nix-mineral.extras.misc.usbguard.enable` --> `services.usbguard.enable`
 
-      `nix-mineral.extras.misc.usbguard.whitelist-at-boot = true;` --> `services.usbguard.presentDevicePolicy = "allow";`
+            `nix-mineral.extras.misc.usbguard.whitelist-at-boot = true;` --> `services.usbguard.presentDevicePolicy = "allow";`
 
-      `nix-mineral.extras.misc.usbguard.gnome-integration = true;` --> `services.usbguard.dbus.enable` and
-      `services.usbguard.IPCAllowedUsers` or `services.usbguard.IPCAllowedGroups`
+            `nix-mineral.extras.misc.usbguard.gnome-integration = true;` --> `services.usbguard.dbus.enable` and
+            `services.usbguard.IPCAllowedUsers` or `services.usbguard.IPCAllowedGroups`
 
-      `services.usbguard.dbus.enable` already integrates with GNOME if your user
-      is allowed access to the IPC.
+            `services.usbguard.dbus.enable` already integrates with GNOME if your user
+            is allowed access to the IPC.
 
-      See:
-      https://github.com/NixOS/nixpkgs/blob/nixos-unstable/nixos/modules/services/security/usbguard.nix
-    '';
-    services.usbguard = {
-      enable = l.mkDefault true;
-      presentDevicePolicy = l.mkIf cfg.whitelist-at-boot (l.mkDefault "allow");
-      dbus.enable = l.mkDefault cfg.gnome-integration;
-    };
-    security.polkit.extraConfig = l.mkIf cfg.gnome-integration ''
-      polkit.addRule(function(action, subject) {
-        if ((action.id == "org.usbguard.Policy1.listRules" ||
-             action.id == "org.usbguard.Policy1.appendRule" ||
-             action.id == "org.usbguard.Policy1.removeRule" ||
-             action.id == "org.usbguard.Devices1.applyDevicePolicy" ||
-             action.id == "org.usbguard.Devices1.listDevices" ||
-             action.id == "org.usbguard1.getParameter" ||
-             action.id == "org.usbguard1.setParameter") &&
-             subject.active == true && subject.local == true &&
-             subject.isInGroup("wheel")) { return polkit.Result.YES; }
-      });
-    '';
-  };
+            See:
+            https://github.com/NixOS/nixpkgs/blob/nixos-unstable/nixos/modules/services/security/usbguard.nix
+          ''
+        ];
+      }
+    )
+    (l.mkIf (cfg.enable == true) {
+      services.usbguard = {
+        enable = l.mkDefault true;
+        presentDevicePolicy = l.mkIf (cfg.whitelist-at-boot == true) (l.mkDefault "allow");
+        dbus.enable = l.mkIf (cfg.gnome-integration == true) (l.mkDefault true);
+      };
+      security.polkit.extraConfig = l.mkIf (cfg.gnome-integration == true) ''
+        polkit.addRule(function(action, subject) {
+          if ((action.id == "org.usbguard.Policy1.listRules" ||
+               action.id == "org.usbguard.Policy1.appendRule" ||
+               action.id == "org.usbguard.Policy1.removeRule" ||
+               action.id == "org.usbguard.Devices1.applyDevicePolicy" ||
+               action.id == "org.usbguard.Devices1.listDevices" ||
+               action.id == "org.usbguard1.getParameter" ||
+               action.id == "org.usbguard1.setParameter") &&
+               subject.active == true && subject.local == true &&
+               subject.isInGroup("wheel")) { return polkit.Result.YES; }
+        });
+      '';
+    })
+  ];
 }

--- a/extras/system/unprivileged-userns.nix
+++ b/extras/system/unprivileged-userns.nix
@@ -22,25 +22,36 @@
 
 {
   options = {
-    unprivileged-userns = l.mkBoolOption ''
-      THIS OPTION IS NOW DEPRECATED. INFORMATION BELOW IS RETAINED FOR
-      FUTURE REFERENCE, AND THIS OPTION IS SCHEDULED TO BE REMOVED PENDING THE
-      NEXT RELEASE.
+    unprivileged-userns = l.mkOption {
+      description = ''
+        THIS OPTION IS NOW DEPRECATED. INFORMATION BELOW IS RETAINED FOR
+        FUTURE REFERENCE, AND THIS OPTION IS SCHEDULED TO BE REMOVED PENDING THE
+        NEXT RELEASE.
 
-      This option DOES NOT work on the upstream NixOS kernel. Setting this
-      does nothing because the requisite sysctl does not exist.
-    '' true;
-  };
-
-  config = l.mkIf (!cfg) {
-    warnings = l.optional (!cfg) ''
-      The option `nix-mineral.extras.system.unprivileged-userns` is deprecated
-      due to being non-functional and will be removed in a future release.
-
-      Please remove this setting from your NixOS configuration.
-    '';
-    boot.kernel.sysctl = {
-      "kernel.unprivileged_userns_clone" = l.mkDefault "0";
+        This option DOES NOT work on the upstream NixOS kernel. Setting this
+        does nothing because the requisite sysctl does not exist.
+      '';
+      default = null;
+      example = false;
+      type = l.types.nullOr l.types.bool;
     };
   };
+
+  config = l.mkMerge [
+    (l.mkIf (l.typeOf cfg == "bool") {
+      warnings = [
+        ''
+          The option `nix-mineral.extras.system.unprivileged-userns` is deprecated
+          due to being non-functional and will be removed in a future release.
+
+          Please remove this setting from your NixOS configuration.
+        ''
+      ];
+    })
+    (l.mkIf (cfg == false) {
+      boot.kernel.sysctl = {
+        "kernel.unprivileged_userns_clone" = l.mkDefault "0";
+      };
+    })
+  ];
 }

--- a/extras/system/zram.nix
+++ b/extras/system/zram.nix
@@ -22,32 +22,43 @@
 
 {
   options = {
-    zram = l.mkBoolOption ''
-      THIS OPTION IS NOW DEPRECATED. INFORMATION BELOW IS RETAINED FOR
-      FUTURE REFERENCE, AND THIS OPTION IS SCHEDULED TO BE REMOVED PENDING THE
-      NEXT RELEASE.
+    zram = l.mkOption {
+      description = ''
+        THIS OPTION IS NOW DEPRECATED. INFORMATION BELOW IS RETAINED FOR
+        FUTURE REFERENCE, AND THIS OPTION IS SCHEDULED TO BE REMOVED PENDING THE
+        NEXT RELEASE.
 
-      Enable zram so that memory is more likely to be compressed instead of
-      written to disk, which may include sensitive information.
+        Enable zram so that memory is more likely to be compressed instead of
+        written to disk, which may include sensitive information.
 
-      Improves storage lifespan and overall performance when swapping as a
-      side effect.
+        Improves storage lifespan and overall performance when swapping as a
+        side effect.
 
-      ::: {.note}
-      Not enabled by default due to interfering with zswap. Additionally, the
-      task of limiting swapping of sensitive data depends highly on the user's
-      individual swapping setup which can't be reliably inferred.
-      :::
-    '' false;
+        ::: {.note}
+        Not enabled by default due to interfering with zswap. Additionally, the
+        task of limiting swapping of sensitive data depends highly on the user's
+        individual swapping setup which can't be reliably inferred.
+        :::
+      '';
+      default = null;
+      example = false;
+      type = l.types.nullOr l.types.bool;
+    };
   };
 
-  config = l.mkIf cfg {
-    warnings = l.optional cfg ''
-      The option `nix-mineral.extras.system.zram` is deprecated due to not
-      aligning with current project scope and will be removed in a future release.
+  config = l.mkMerge [
+    (l.mkIf (l.typeOf cfg == "bool") {
+      warnings = [
+        ''
+          The option `nix-mineral.extras.system.zram` is deprecated due to not
+          aligning with current project scope and will be removed in a future release.
 
-      Replace with `zramSwap.enable` instead.
-    '';
-    zramSwap.enable = true;
-  };
+          Replace with `zramSwap.enable` instead.
+        ''
+      ];
+    })
+    (l.mkIf (cfg == true) {
+      zramSwap.enable = true;
+    })
+  ];
 }

--- a/presets/compatibility.nix
+++ b/presets/compatibility.nix
@@ -37,10 +37,6 @@
         # if false, may prevent low resource systems from booting.
         busmaster-bit = true;
 
-        # Enable loading of unsigned kernel modules and enable hibernation.
-        lockdown = false;
-        only-signed-modules = false;
-
         # Don't crash the system if faulty drivers produce kernel oopses
         oops-panic = false;
       };
@@ -93,18 +89,6 @@
       special = {
         # Disable access restriction on /proc. Fix Gnome/Wayland.
         "/proc".options.hidepid = false;
-      };
-    };
-
-    extras = {
-      misc = {
-        # (only enables if usbguard.enable is true)
-        usbguard = {
-          # Enables USB device authorization at boot.
-          whitelist-at-boot = true;
-          # Enables integration with GNOME Shell.
-          gnome-integration = true;
-        };
       };
     };
   };

--- a/presets/maximum.nix
+++ b/presets/maximum.nix
@@ -68,9 +68,6 @@
         # Replace systemd-timesyncd with chrony for NTP, and configure chrony for NTS
         # and to use the seccomp filter for security.
         secure-chrony = true;
-
-        # if false, this may break some applications that rely on user namespaces.
-        unprivileged-userns = false;
       };
 
       network = {
@@ -80,16 +77,6 @@
         # if false, may help mitigate TCP reset DoS attacks, but
         # may also harm network performance when at high latencies.
         tcp-window-scaling = false;
-      };
-
-      misc = {
-        # Replace sudo with doas, doas has a lower attack surface, but is less audited.
-        replace-sudo-with-doas = true;
-        doas-sudo-wrapper = true;
-
-        # Enable USBGuard, a tool to restrict USB devices.
-        # (blocks any USB devices, maybe enable usbguard.whitelist-at-boot)
-        usbguard.enable = true;
       };
     };
   };

--- a/presets/performance.nix
+++ b/presets/performance.nix
@@ -46,11 +46,6 @@
         # https://www.ieee-security.org/TC/SP2013/papers/4977a191.pdf
         pti = false;
 
-        # Don't use kcfi as the control flow implementation in the kernel,
-        # since it performs worse than FineIBT, which is the current Linux
-        # kernel (not nix-mineral) default.
-        kcfi = false;
-
         # Do not enable red zoning and sanity checking with slab debug, since
         # it adds significant memory allocation overhead.
         slab-debug = false;

--- a/settings/entropy/aslr-max-bits.nix
+++ b/settings/entropy/aslr-max-bits.nix
@@ -22,43 +22,48 @@
 
 {
   options = {
-    aslr-max-bits = l.mkBoolOption ''
-      Use the maximum number of bits of entropy to address space layout
-      randomization, a widely used mitigation against memory exploits.
+    aslr-max-bits = l.mkOption {
+      description = ''
+        Use the maximum number of bits of entropy to address space layout
+        randomization, a widely used mitigation against memory exploits.
 
-      ::: {.note}
-      THIS OPTION IS NOW DEPRECATED. INFORMATION BELOW IS RETAINED FOR
-      FUTURE REFERENCE, AND THIS OPTION IS SCHEDULED TO BE REMOVED PENDING THE
-      NEXT RELEASE.
+        ::: {.note}
+        THIS OPTION IS NOW DEPRECATED. INFORMATION BELOW IS RETAINED FOR
+        FUTURE REFERENCE, AND THIS OPTION IS SCHEDULED TO BE REMOVED PENDING THE
+        NEXT RELEASE.
 
-      The values used here are currently only valid for x86_64.
+        The values used here are currently only valid for x86_64.
 
-      Other CPU architectures may require different numbers here, consult
-      upstream documentation as necessary.
-      :::
+        Other CPU architectures may require different numbers here, consult
+        upstream documentation as necessary.
+        :::
 
-      ::: {.note}
-      See:
-      - https://en.wikipedia.org/wiki/Address_space_layout_randomization
-      :::
-    '' false;
+        ::: {.note}
+        See:
+        - https://en.wikipedia.org/wiki/Address_space_layout_randomization
+        :::
+      '';
+      default = null;
+      example = false;
+      type = l.types.nullOr l.types.bool;
+    };
   };
 
-  config = l.mkIf cfg {
-    warnings = l.optional cfg ''
-      The option `nix-mineral.settings.entropy.aslr-max-bits` is deprecated
-      due to being integrated upstream and will be removed in a future release.
+  config = (
+    l.mkIf (l.typeOf cfg == "bool") {
+      warnings = [
+        ''
+          The option `nix-mineral.settings.entropy.aslr-max-bits` is deprecated
+          due to being integrated upstream and will be removed in a future release.
 
-      See: https://github.com/NixOS/nixpkgs/commit/4971c9331a72deeda85ba8d8018a5b07ee6f1635
+          See: https://github.com/NixOS/nixpkgs/commit/4971c9331a72deeda85ba8d8018a5b07ee6f1635
 
-      This option no longer does anything in order to avoid evaluation
-      conflicts on NixOS unstable as of 4/24/26.
+          This option no longer does anything in order to avoid evaluation
+          conflicts on NixOS unstable as of 4/24/26.
 
-      Use `boot.kernel.sysctl."vm.mmap_rnd_bits"` instead.
-    '';
-    # boot.kernel.sysctl = {
-    #   "vm.mmap_rnd_bits" = l.mkDefault "32";
-    #   "vm.mmap_rnd_compat_bits" = l.mkDefault "16";
-    # };
-  };
+          Use `boot.kernel.sysctl."vm.mmap_rnd_bits"` instead.
+        ''
+      ];
+    }
+  );
 }

--- a/settings/kernel/kcfi.nix
+++ b/settings/kernel/kcfi.nix
@@ -22,37 +22,48 @@
 
 {
   options = {
-    kcfi = l.mkBoolOption ''
-      THIS OPTION IS NOW DEPRECATED. INFORMATION BELOW IS RETAINED FOR
-      FUTURE REFERENCE, AND THIS OPTION IS SCHEDULED TO BE REMOVED PENDING THE
-      NEXT RELEASE.
+    kcfi = l.mkOption {
+      description = ''
+        THIS OPTION IS NOW DEPRECATED. INFORMATION BELOW IS RETAINED FOR
+        FUTURE REFERENCE, AND THIS OPTION IS SCHEDULED TO BE REMOVED PENDING THE
+        NEXT RELEASE.
 
-      This option does nothing on the upstream NixOS kernel because it is
-      not compiled with clang CFI. The benefits of kCFI compared to FineIBT
-      are disputed.
+        This option does nothing on the upstream NixOS kernel because it is
+        not compiled with clang CFI. The benefits of kCFI compared to FineIBT
+        are disputed.
 
-      If set to true, switch (back) to using kCFI as the default Control Flow
-      Integrity (CFI) implementation as kCFI mandates hash validation at the
-      source making it more difficult to bypass.
+        If set to true, switch (back) to using kCFI as the default Control Flow
+        Integrity (CFI) implementation as kCFI mandates hash validation at the
+        source making it more difficult to bypass.
 
-      This is in contrast to FineIBT which was made the default in kernel 6.2
-      due to its performance benefits as it only performs hash checks at the
-      destinations.
+        This is in contrast to FineIBT which was made the default in kernel 6.2
+        due to its performance benefits as it only performs hash checks at the
+        destinations.
 
-      ::: {.note}
-      See:
-      - https://docs.kernel.org/next/x86/shstk.html
-      :::
-    '' false;
+        ::: {.note}
+        See:
+        - https://docs.kernel.org/next/x86/shstk.html
+        :::
+      '';
+      default = null;
+      example = false;
+      type = l.types.nullOr l.types.bool;
+    };
   };
 
-  config = l.mkIf cfg {
-    warnings = l.optional cfg ''
-      The option `nix-mineral.settings.kernel.kcfi` is deprecated
-      due to being non-functional and will be removed in a future release.
+  config = l.mkMerge [
+    (l.mkIf (l.typeOf cfg == "bool") {
+      warnings = [
+        ''
+          The option `nix-mineral.settings.kernel.kcfi` is deprecated
+          due to being non-functional and will be removed in a future release.
 
-      Please remove this setting from your NixOS configuration.
-    '';
-    boot.kernelParams = [ "cfi=kcfi" ];
-  };
+          Please remove this setting from your NixOS configuration.
+        ''
+      ];
+    })
+    (l.mkIf (cfg == true) {
+      boot.kernelParams = [ "cfi=kcfi" ];
+    })
+  ];
 }

--- a/settings/kernel/lockdown.nix
+++ b/settings/kernel/lockdown.nix
@@ -22,36 +22,47 @@
 
 {
   options = {
-    lockdown = l.mkBoolOption ''
-      Enable linux kernel lockdown, this blocks loading of unsigned kernel modules
-      and breaks hibernation.
+    lockdown = l.mkOption {
+      description = ''
+        Enable linux kernel lockdown, this blocks loading of unsigned kernel modules
+        and breaks hibernation.
 
-      ::: {.note}
-      THIS OPTION IS NOW DEPRECATED. INFORMATION BELOW IS RETAINED FOR
-      FUTURE REFERENCE, AND THIS OPTION IS SCHEDULED TO BE REMOVED PENDING THE
-      NEXT RELEASE.
+        ::: {.note}
+        THIS OPTION IS NOW DEPRECATED. INFORMATION BELOW IS RETAINED FOR
+        FUTURE REFERENCE, AND THIS OPTION IS SCHEDULED TO BE REMOVED PENDING THE
+        NEXT RELEASE.
 
-      This currently does nothing as the default NixOS kernel config does not
-      enable Linux kernel lockdown as of 16/03/26.
+        This currently does nothing as the default NixOS kernel config does not
+        enable Linux kernel lockdown as of 16/03/26.
 
-      See:
-      https://github.com/NixOS/nixpkgs/blob/baeac6edff1b03f0ecd063b8fe48e9742d0527e7/pkgs/os-specific/linux/kernel/common-config.nix#L830
-      https://github.com/cynicsketch/nix-mineral/issues/125
+        See:
+        https://github.com/NixOS/nixpkgs/blob/baeac6edff1b03f0ecd063b8fe48e9742d0527e7/pkgs/os-specific/linux/kernel/common-config.nix#L830
+        https://github.com/cynicsketch/nix-mineral/issues/125
 
-      If `false`, you probably want to disable {option}`nix-mineral.settings.kernel.only-signed-modules`.
-      :::
-    '' false;
+        If `false`, you probably want to disable {option}`nix-mineral.settings.kernel.only-signed-modules`.
+        :::
+      '';
+      default = null;
+      example = false;
+      type = l.types.nullOr l.types.bool;
+    };
   };
 
-  config = l.mkIf cfg {
-    warnings = l.optional cfg ''
-      The option `nix-mineral.settings.kernel.lockdown` is deprecated
-      due to being non-functional and will be removed in a future release.
+  config = l.mkMerge [
+    (l.mkIf (l.typeOf cfg == "bool") {
+      warnings = [
+        ''
+          The option `nix-mineral.settings.kernel.lockdown` is deprecated
+          due to being non-functional and will be removed in a future release.
 
-      Please remove this setting from your NixOS configuration.
-    '';
-    boot.kernelParams = [
-      "lockdown=confidentiality"
-    ];
-  };
+          Please remove this setting from your NixOS configuration.
+        ''
+      ];
+    })
+    (l.mkIf (cfg == true) {
+      boot.kernelParams = [
+        "lockdown=confidentiality"
+      ];
+    })
+  ];
 }

--- a/settings/kernel/only-signed-modules.nix
+++ b/settings/kernel/only-signed-modules.nix
@@ -22,39 +22,50 @@
 
 {
   options = {
-    only-signed-modules = l.mkBoolOption ''
-      Requires all kernel modules to be signed. This prevents out-of-tree
-      kernel modules from working unless signed.
+    only-signed-modules = l.mkOption {
+      description = ''
+        Requires all kernel modules to be signed. This prevents out-of-tree
+        kernel modules from working unless signed.
 
-      ::: {.note}
-      THIS OPTION IS NOW DEPRECATED. INFORMATION BELOW IS RETAINED FOR
-      FUTURE REFERENCE, AND THIS OPTION IS SCHEDULED TO BE REMOVED PENDING THE
-      NEXT RELEASE.
+        ::: {.note}
+        THIS OPTION IS NOW DEPRECATED. INFORMATION BELOW IS RETAINED FOR
+        FUTURE REFERENCE, AND THIS OPTION IS SCHEDULED TO BE REMOVED PENDING THE
+        NEXT RELEASE.
 
-      This currently does nothing as the default NixOS kernel config does not
-      enable Linux kernel lockdown as of 16/03/26.
+        This currently does nothing as the default NixOS kernel config does not
+        enable Linux kernel lockdown as of 16/03/26.
 
-      It will remain implemented by default in the event that circumstances
-      change, since adding the corresponding boot parameter anyways is harmless.
+        It will remain implemented by default in the event that circumstances
+        change, since adding the corresponding boot parameter anyways is harmless.
 
-      See:
-      https://github.com/NixOS/nixpkgs/blob/baeac6edff1b03f0ecd063b8fe48e9742d0527e7/pkgs/os-specific/linux/kernel/common-config.nix#L830
-      https://github.com/cynicsketch/nix-mineral/issues/125
+        See:
+        https://github.com/NixOS/nixpkgs/blob/baeac6edff1b03f0ecd063b8fe48e9742d0527e7/pkgs/os-specific/linux/kernel/common-config.nix#L830
+        https://github.com/cynicsketch/nix-mineral/issues/125
 
-      If `false`, {option}`nix-mineral.settings.kernel.lockdown` must also be false.
-      :::
-    '' false;
+        If `false`, {option}`nix-mineral.settings.kernel.lockdown` must also be false.
+        :::
+      '';
+      default = null;
+      example = false;
+      type = l.types.nullOr l.types.bool;
+    };
   };
 
-  config = l.mkIf cfg {
-    warnings = l.optional cfg ''
-      The option `nix-mineral.settings.kernel.only-signed-modules` is deprecated
-      due to being non-functional and will be removed in a future release.
+  config = l.mkMerge [
+    (l.mkIf (l.typeOf cfg == "bool") {
+      warnings = [
+        ''
+          The option `nix-mineral.settings.kernel.only-signed-modules` is deprecated
+          due to being non-functional and will be removed in a future release.
 
-      Please remove this setting from your NixOS configuration.
-    '';
-    boot.kernelParams = [
-      "module.sig_enforce=1"
-    ];
-  };
+          Please remove this setting from your NixOS configuration.
+        ''
+      ];
+    })
+    (l.mkIf (cfg == true) {
+      boot.kernelParams = [
+        "module.sig_enforce=1"
+      ];
+    })
+  ];
 }


### PR DESCRIPTION
Breaking changes: Presets may not have expected behavior as backwards compatibility is not preserved within them.