### PR TITLE
Remove hidepid by default

### DIFF
--- a/docs/OMITTED.md
+++ b/docs/OMITTED.md
@@ -63,6 +63,8 @@ which is not default behavior!) \
 22 (Advice)
 
 ## Sections from madaidan's guide requiring manual user intervention:
+2.4 (Excluded due to significant breakage and trivial bypasses during typical usage. See:
+    https://github.com/secureblue/secureblue/issues/101, https://github.com/systemd/systemd/issues/29893)
 2.7 (systemd service hardening must be done manually) \
 2.9 (Paid software) \
 2.11 (Unique for all hardware, inconvenient) \

--- a/filesystems/special.nix
+++ b/filesystems/special.nix
@@ -104,25 +104,10 @@ in
 
       "/dev".enable = l.mkDefault true;
 
-      # Hide processes from other users except root, may cause breakage.
-      # change options."hidepid" to false if you want to disable.
       "/proc" = {
         enable = l.mkDefault true;
         device = l.mkDefault "proc";
-        options = {
-          "hidepid" = l.mkDefault 2;
-          "gid" = l.mkDefault config.users.groups.proc.gid;
-        };
       };
     };
-
-    # Add "proc" group to whitelist /proc access and allow systemd-logind to view
-    # /proc in order to unbreak it, as well as to user@ for similar reasons.
-    # See https://github.com/systemd/systemd/issues/12955, and https://github.com/Kicksecure/security-misc/issues/208
-    users.groups.proc.gid = l.mkIf parentCfg.enable (l.mkDefault config.ids.gids.proc);
-    systemd.services.systemd-logind.serviceConfig.SupplementaryGroups = l.mkIf parentCfg.enable [
-      "proc"
-    ];
-    systemd.services."user@".serviceConfig.SupplementaryGroups = l.mkIf parentCfg.enable [ "proc" ];
   };
 }


### PR DESCRIPTION
Has lead to significant breakage while having minimal utility due to adjacent leaks.
Sandboxes already cover the issue this is supposed to solve, while resolving side channels.

See:
https://github.com/secureblue/secureblue/issues/101
https://github.com/systemd/systemd/issues/29893