### PR TITLE
contributing: disallow stateful changes

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -22,6 +22,7 @@ One of the main ideas is to be as modular as possible, so don't create modules t
 - Invert options that are intended to disable something, for example: don't use `disable-example-feature-y`, use `example-feature-y` and set the default to `false`.
 - Use the `l.mkBoolOption` function to create boolean options.
 - Do not attempt to add any feature which has been intentionally excluded under [OMITTED.md](OMITTED.md) or [ADDITIONAL-RESOURCES.md](ADDITIONAL-RESOURCES.md) without first creating an issue.
+- In general, do not add stateful features. All changes should be readily able to be rolled back with a rebuild.
 - Issues should be created for most feature changes before attempting a PR. Bug fixes, and minor documentation changes do not require issues, but it is still heavily encouraged.
 - Where applicable, update both [presets](https://github.com/cynicsketch/nix-mineral/tree/main/presets) and the [README](https://github.com/cynicsketch/nix-mineral/tree/main/README.md) to reflect any new options.
 - Use `l.mkOverride 900` over `l.mkForce` when forcefully overriding NixOS defaults is necessary, to make sure it actually applies.


### PR DESCRIPTION
Stateful changes add complexity and can result in unpredictible side effects, and should not be added going forward due to the potential to cause irreversible breakage. See: https://github.com/cynicsketch/nix-mineral/issues/160