### PR TITLE
Support for using nixpkgs mkXOptionModule functions

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -214,15 +214,9 @@ let
       };
 in
 {
-  options = {
-    new-category = l.mkOption {
-      description = ''
-        This is a new category example.
-      '';
-      default = { };
-      type = l.mkCategorySubmodule categoryModules;
-    };
-  };
+  imports = l.mkCategoryImports categoryModules;
+
+  options.new-category = l.mkCategoryOptions categoryModules;
 
   config = l.mkCategoryConfig categoryModules;
 }

--- a/extras/entropy/default.nix
+++ b/extras/entropy/default.nix
@@ -40,15 +40,7 @@ let
       };
 in
 {
-  options = {
-    entropy = l.mkOption {
-      description = ''
-        Modify entropy settings for improved security
-      '';
-      default = { };
-      type = l.mkCategorySubmodule categoryModules;
-    };
-  };
+  options.entropy = l.mkCategoryOptions categoryModules;
 
   config = l.mkCategoryConfig categoryModules;
 }

--- a/extras/entropy/default.nix
+++ b/extras/entropy/default.nix
@@ -40,6 +40,8 @@ let
       };
 in
 {
+  imports = l.mkCategoryImports categoryModules;
+
   options.entropy = l.mkCategoryOptions categoryModules;
 
   config = l.mkCategoryConfig categoryModules;

--- a/extras/kernel/default.nix
+++ b/extras/kernel/default.nix
@@ -42,6 +42,8 @@ let
       };
 in
 {
+  imports = l.mkCategoryImports categoryModules;
+
   options.kernel = l.mkCategoryOptions categoryModules;
 
   config = l.mkCategoryConfig categoryModules;

--- a/extras/kernel/default.nix
+++ b/extras/kernel/default.nix
@@ -42,15 +42,7 @@ let
       };
 in
 {
-  options = {
-    kernel = l.mkOption {
-      description = ''
-        Extra settings to harden the linux kernel.
-      '';
-      default = { };
-      type = l.mkCategorySubmodule categoryModules;
-    };
-  };
+  options.kernel = l.mkCategoryOptions categoryModules;
 
   config = l.mkCategoryConfig categoryModules;
 }

--- a/extras/misc/default.nix
+++ b/extras/misc/default.nix
@@ -44,17 +44,7 @@ let
       };
 in
 {
-  options = {
-    misc = l.mkOption {
-      description = ''
-        Extra misc settings.
-
-        Most of those are relatively opinionated additional software.
-      '';
-      default = { };
-      type = l.mkCategorySubmodule categoryModules;
-    };
-  };
+  options.misc = l.mkCategoryOptions categoryModules;
 
   config = l.mkCategoryConfig categoryModules;
 }

--- a/extras/misc/default.nix
+++ b/extras/misc/default.nix
@@ -44,6 +44,8 @@ let
       };
 in
 {
+  imports = l.mkCategoryImports categoryModules;
+
   options.misc = l.mkCategoryOptions categoryModules;
 
   config = l.mkCategoryConfig categoryModules;

--- a/extras/network/default.nix
+++ b/extras/network/default.nix
@@ -41,6 +41,8 @@ let
       };
 in
 {
+  imports = l.mkCategoryImports categoryModules;
+
   options.network = l.mkCategoryOptions categoryModules;
 
   config = l.mkCategoryConfig categoryModules;

--- a/extras/network/default.nix
+++ b/extras/network/default.nix
@@ -41,15 +41,7 @@ let
       };
 in
 {
-  options = {
-    network = l.mkOption {
-      description = ''
-        Extra settings for the network.
-      '';
-      default = { };
-      type = l.mkCategorySubmodule categoryModules;
-    };
-  };
+  options.network = l.mkCategoryOptions categoryModules;
 
   config = l.mkCategoryConfig categoryModules;
 }

--- a/extras/system/default.nix
+++ b/extras/system/default.nix
@@ -45,15 +45,7 @@ let
       };
 in
 {
-  options = {
-    system = l.mkOption {
-      description = ''
-        Extra settings for the system.
-      '';
-      default = { };
-      type = l.mkCategorySubmodule categoryModules;
-    };
-  };
+  options.system = l.mkCategoryOptions categoryModules;
 
   config = l.mkCategoryConfig categoryModules;
 }

--- a/extras/system/default.nix
+++ b/extras/system/default.nix
@@ -45,6 +45,8 @@ let
       };
 in
 {
+  imports = l.mkCategoryImports categoryModules;
+
   options.system = l.mkCategoryOptions categoryModules;
 
   config = l.mkCategoryConfig categoryModules;

--- a/extras/tmpfiles/default.nix
+++ b/extras/tmpfiles/default.nix
@@ -41,15 +41,7 @@ let
       };
 in
 {
-  options = {
-    tmpfiles = l.mkOption {
-      description = ''
-        Use systemd-tmpfiles to restrict file permissions in various folders.
-      '';
-      default = { };
-      type = l.mkCategorySubmodule categoryModules;
-    };
-  };
+  options.tmpfiles = l.mkCategoryOptions categoryModules;
 
   config = l.mkCategoryConfig categoryModules;
 }

--- a/extras/tmpfiles/default.nix
+++ b/extras/tmpfiles/default.nix
@@ -41,6 +41,8 @@ let
       };
 in
 {
+  imports = l.mkCategoryImports categoryModules;
+
   options.tmpfiles = l.mkCategoryOptions categoryModules;
 
   config = l.mkCategoryConfig categoryModules;

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -48,7 +48,7 @@ let
   # import wrapper to pass extra args to a module
   # used to pass the `l` variable to every module, and used in the importCategoryModule function to pass parentCfg and cfg.
   importModule =
-    path: extraArgs: # `extraArgs` is a attrset that can contain any additional arguments to pass to the module
+    module: extraArgs: # `extraArgs` is a attrset that can contain any additional arguments to pass to the module
     (
       {
         lib,
@@ -57,7 +57,7 @@ let
         pkgs,
         ...
       }:
-      ((import path) (
+      ((if lib.typeOf module == "path" then import module else module) (
         {
           inherit
             lib
@@ -76,6 +76,7 @@ let
               mkCategoryModules
               mkCategoryOptions
               mkCategoryConfig
+              mkCategoryImports
               mkFilesystemOptions
               ;
           };
@@ -147,6 +148,25 @@ let
   # create a config for a list of categoryModules created with `mkCategoryModules`
   # use this to define a `config = ...` attrset
   mkCategoryConfig = modules: (l.mkMerge (l.map (module: module.config) modules));
+
+  # create a list of imports for a list of categoryModules created with `mkCategoryModules
+  # this uses `importModule` to import the modules, so it will pass the `l` variable to every module
+  # use this to define an `imports = ...` attrset
+  mkCategoryImports =
+    modules:
+    l.concatMap (
+      module:
+      if module ? imports then
+        (l.map (
+          moduleImport:
+          if l.typeOf moduleImport == "path" || l.typeOf moduleImport == "lambda" then
+            importModule moduleImport { }
+          else
+            moduleImport
+        ) module.imports)
+      else
+        [ ]
+    ) modules;
 in
 {
   flake.lib = {
@@ -159,6 +179,7 @@ in
       mkCategoryModules
       mkCategoryOptions
       mkCategoryConfig
+      mkCategoryImports
       ;
   };
 }

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -74,7 +74,7 @@ let
               importModule
               importCategoryModule
               mkCategoryModules
-              mkCategorySubmodule
+              mkCategoryOptions
               mkCategoryConfig
               mkFilesystemOptions
               ;
@@ -141,15 +141,8 @@ let
     categoryConfig: paths: args:
     l.map (path: (importCategoryModule categoryConfig path args)) paths;
 
-  # create a submodule type for a list of categoryModules created with `mkCategoryModules`
-  mkCategorySubmodule =
-    modules:
-    (l.types.submoduleWith {
-      shorthandOnlyDefinesConfig = true;
-      modules = l.map (module: {
-        inherit (module) options;
-      }) modules;
-    });
+  # create an attrset with all options from a list of categoryModules created with `mkCategoryModules`
+  mkCategoryOptions = modules: l.mergeAttrsList (l.map (module: module.options) modules);
 
   # create a config for a list of categoryModules created with `mkCategoryModules`
   # use this to define a `config = ...` attrset
@@ -164,7 +157,7 @@ in
       importModule
       importCategoryModule
       mkCategoryModules
-      mkCategorySubmodule
+      mkCategoryOptions
       mkCategoryConfig
       ;
   };

--- a/nix-mineral.nix
+++ b/nix-mineral.nix
@@ -86,7 +86,10 @@ in
 {
   imports = [
     (l.importModule ./presets { })
-  ];
+  ]
+  ++ (l.mkCategoryImports settingsModules)
+  ++ (l.mkCategoryImports extrasModules)
+  ++ (l.mkCategoryImports filesystemsModules);
 
   options = {
     nix-mineral = {

--- a/nix-mineral.nix
+++ b/nix-mineral.nix
@@ -92,29 +92,11 @@ in
     nix-mineral = {
       enable = l.mkEnableOption "the nix-mineral module";
 
-      settings = l.mkOption {
-        description = ''
-          nix-mineral settings.
-        '';
-        default = { };
-        type = l.mkCategorySubmodule settingsModules;
-      };
+      settings = l.mkCategoryOptions settingsModules;
 
-      extras = l.mkOption {
-        description = ''
-          Extra options that are not part of the main configuration.
-        '';
-        default = { };
-        type = l.mkCategorySubmodule extrasModules;
-      };
+      extras = l.mkCategoryOptions extrasModules;
 
-      filesystems = l.mkOption {
-        description = ''
-          Utility for hardening filesystems and special filesystems.
-        '';
-        default = { };
-        type = l.mkCategorySubmodule filesystemsModules;
-      };
+      filesystems = l.mkCategoryOptions filesystemsModules;
     };
   };
 

--- a/settings/debug/default.nix
+++ b/settings/debug/default.nix
@@ -47,6 +47,8 @@ let
       };
 in
 {
+  imports = l.mkCategoryImports categoryModules;
+
   options.debug = l.mkCategoryOptions categoryModules;
 
   config = l.mkCategoryConfig categoryModules;

--- a/settings/debug/default.nix
+++ b/settings/debug/default.nix
@@ -47,16 +47,7 @@ let
       };
 in
 {
-  options = {
-    debug = l.mkOption {
-      description = ''
-        Limit various debugging information to reduce info available to
-        potential attackers.
-      '';
-      default = { };
-      type = l.mkCategorySubmodule categoryModules;
-    };
-  };
+  options.debug = l.mkCategoryOptions categoryModules;
 
   config = l.mkCategoryConfig categoryModules;
 }

--- a/settings/entropy/default.nix
+++ b/settings/entropy/default.nix
@@ -43,6 +43,8 @@ let
       };
 in
 {
+  imports = l.mkCategoryImports categoryModules;
+
   options.entropy = l.mkCategoryOptions categoryModules;
 
   config = l.mkCategoryConfig categoryModules;

--- a/settings/entropy/default.nix
+++ b/settings/entropy/default.nix
@@ -43,15 +43,7 @@ let
       };
 in
 {
-  options = {
-    entropy = l.mkOption {
-      description = ''
-        Settings for entropy sources.
-      '';
-      default = { };
-      type = l.mkCategorySubmodule categoryModules;
-    };
-  };
+  options.entropy = l.mkCategoryOptions categoryModules;
 
   config = l.mkCategoryConfig categoryModules;
 }

--- a/settings/etc/default.nix
+++ b/settings/etc/default.nix
@@ -45,15 +45,7 @@ let
       };
 in
 {
-  options = {
-    etc = l.mkOption {
-      description = ''
-        Modify files in `/etc` to limit attack surface.
-      '';
-      default = { };
-      type = l.mkCategorySubmodule categoryModules;
-    };
-  };
+  options.etc = l.mkCategoryOptions categoryModules;
 
   config = l.mkCategoryConfig categoryModules;
 }

--- a/settings/etc/default.nix
+++ b/settings/etc/default.nix
@@ -45,6 +45,8 @@ let
       };
 in
 {
+  imports = l.mkCategoryImports categoryModules;
+
   options.etc = l.mkCategoryOptions categoryModules;
 
   config = l.mkCategoryConfig categoryModules;

--- a/settings/kernel/default.nix
+++ b/settings/kernel/default.nix
@@ -72,17 +72,7 @@ let
       };
 in
 {
-  options = {
-    kernel = l.mkOption {
-      description = ''
-        Settings meant to harden the Linux kernel against attack, as it presents
-        a large, privileged attack surface that may be used to bypass security
-        policies or escape sandboxes.
-      '';
-      default = { };
-      type = l.mkCategorySubmodule categoryModules;
-    };
-  };
+  options.kernel = l.mkCategoryOptions categoryModules;
 
   config = l.mkCategoryConfig categoryModules;
 }

--- a/settings/kernel/default.nix
+++ b/settings/kernel/default.nix
@@ -72,6 +72,8 @@ let
       };
 in
 {
+  imports = l.mkCategoryImports categoryModules;
+
   options.kernel = l.mkCategoryOptions categoryModules;
 
   config = l.mkCategoryConfig categoryModules;

--- a/settings/misc/default.nix
+++ b/settings/misc/default.nix
@@ -42,15 +42,7 @@ let
       };
 in
 {
-  options = {
-    misc = l.mkOption {
-      description = ''
-        Configure miscellaneous settings, usually additional software.
-      '';
-      default = { };
-      type = l.mkCategorySubmodule categoryModules;
-    };
-  };
+  options.misc = l.mkCategoryOptions categoryModules;
 
   config = l.mkCategoryConfig categoryModules;
 }

--- a/settings/misc/default.nix
+++ b/settings/misc/default.nix
@@ -42,6 +42,8 @@ let
       };
 in
 {
+  imports = l.mkCategoryImports categoryModules;
+
   options.misc = l.mkCategoryOptions categoryModules;
 
   config = l.mkCategoryConfig categoryModules;

--- a/settings/network/default.nix
+++ b/settings/network/default.nix
@@ -56,15 +56,7 @@ let
       };
 in
 {
-  options = {
-    network = l.mkOption {
-      description = ''
-        Settings for the network.
-      '';
-      default = { };
-      type = l.mkCategorySubmodule categoryModules;
-    };
-  };
+  options.network = l.mkCategoryOptions categoryModules;
 
   config = l.mkCategoryConfig categoryModules;
 }

--- a/settings/network/default.nix
+++ b/settings/network/default.nix
@@ -56,6 +56,8 @@ let
       };
 in
 {
+  imports = l.mkCategoryImports categoryModules;
+
   options.network = l.mkCategoryOptions categoryModules;
 
   config = l.mkCategoryConfig categoryModules;

--- a/settings/pam/default.nix
+++ b/settings/pam/default.nix
@@ -42,6 +42,8 @@ let
       };
 in
 {
+  imports = l.mkCategoryImports categoryModules;
+
   options.pam = l.mkCategoryOptions categoryModules;
 
   config = l.mkCategoryConfig categoryModules;

--- a/settings/pam/default.nix
+++ b/settings/pam/default.nix
@@ -42,15 +42,7 @@ let
       };
 in
 {
-  options = {
-    pam = l.mkOption {
-      description = ''
-        Modify pluggable authentication module (PAM) settings.
-      '';
-      default = { };
-      type = l.mkCategorySubmodule categoryModules;
-    };
-  };
+  options.pam = l.mkCategoryOptions categoryModules;
 
   config = l.mkCategoryConfig categoryModules;
 }

--- a/settings/system/default.nix
+++ b/settings/system/default.nix
@@ -45,15 +45,7 @@ let
       };
 in
 {
-  options = {
-    system = l.mkOption {
-      description = ''
-        Settings for the system.
-      '';
-      default = { };
-      type = l.mkCategorySubmodule categoryModules;
-    };
-  };
+  options.system = l.mkCategoryOptions categoryModules;
 
   config = l.mkCategoryConfig categoryModules;
 }

--- a/settings/system/default.nix
+++ b/settings/system/default.nix
@@ -45,6 +45,8 @@ let
       };
 in
 {
+  imports = l.mkCategoryImports categoryModules;
+
   options.system = l.mkCategoryOptions categoryModules;
 
   config = l.mkCategoryConfig categoryModules;


### PR DESCRIPTION
`mkXOptionModule` I mean `mkAliasOptionModule`, `mkChangedOptionModule`, `mkMergedOptionModule`, `mkRemovedOptionModule` and `mkRenamedOptionModule`.

As discussed in #174, the project [does not support theses functions](https://github.com/cynicsketch/nix-mineral/pull/174#issuecomment-5121597540) because it relies on submodules, so the decision was to stop using them. I decided to split this into a new PR, as it is important to merge it quickly given the number of recent deprecations.